### PR TITLE
Alteração para ser possível verificar dois eventos no mesmo dia

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "parsel",
   "python-decouple",
   "python-telegram-bot[job-queue]",
+  "parameterized"
 ]
 
 [build-system]

--- a/src/joker/commands/calendar.py
+++ b/src/joker/commands/calendar.py
@@ -25,11 +25,11 @@ def get_events(when=""):
 
     if when == "future":
         events = [
-            event for event in all_events if event.begin.time() >= datetime.datetime.now().time()
+            event for event in all_events if event.begin.time().hour >= datetime.datetime.now().time().hour
         ]
     elif when == "today":
         events = [
-            event for event in all_events if event.begin.time() >= datetime.datetime.now().time()
+            event for event in all_events if event.begin.time().hour >= datetime.datetime.now().time().hour
         ]
     else:
         events = all_events

--- a/src/joker/commands/calendar.py
+++ b/src/joker/commands/calendar.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 import httpx
-from ics import Calendar
+import ics
 from telegram.constants import ParseMode
 
 from joker import settings
@@ -19,7 +19,7 @@ def get_events(when=""):
         time.sleep(1)
         response = httpx.get(settings.ICS_LOCATION)
 
-    calendar = Calendar(response.text)
+    calendar = ics.Calendar(response.text)
 
     all_events = list({event for event in calendar.events})
 
@@ -29,7 +29,7 @@ def get_events(when=""):
         ]
     elif when == "today":
         events = [
-            event for event in all_events if event.begin.date() == datetime.date.today()
+            event for event in all_events if event.begin.time() >= datetime.datetime.now().time()
         ]
     else:
         events = all_events

--- a/src/joker/commands/calendar.py
+++ b/src/joker/commands/calendar.py
@@ -25,7 +25,7 @@ def get_events(when=""):
 
     if when == "future":
         events = [
-            event for event in all_events if event.begin.date() >= datetime.date.today()
+            event for event in all_events if event.begin.time() >= datetime.datetime.now().time()
         ]
     elif when == "today":
         events = [

--- a/test/calendar_test.py
+++ b/test/calendar_test.py
@@ -1,0 +1,120 @@
+import unittest
+import os
+from datetime import datetime, timedelta
+
+from unittest.mock import patch, Mock
+
+from ics import Event
+
+import joker.commands.calendar as cal
+
+gancio_events_json_response = [{
+    "id": 164,
+    "title": "Oficina de IoT: Quinta Temporada - Março",
+    "slug": "oficina-de-iot-quinta-temporada-marco",
+    "start_datetime": 1741818600,
+    "end_datetime": 1741824000,
+    "media": [
+      {
+        "url": "536a0f4aa63815e48e991c8ddd321a19.jpg",
+        "height": 675,
+        "width": 1200,
+        "name": "Oficina de IoT: Quinta Temporada - Março",
+        "size": 90844,
+        "focalpoint": [
+          0,
+          0
+        ]
+      }
+    ],
+    "online_locations": [
+      "https://pretix.lhc.net.br/IoT/iotx02/"
+    ],
+    "updatedAt": "2025-02-25T15:15:45.216Z",
+    "apUserApId": None,
+    "tags": [
+      "Oficina de IoT",
+      "comunidade",
+      "hardware",
+      "iot",
+      "oficinadeiot",
+      "plaquinhas"
+    ],
+    "place": {
+      "id": 1,
+      "name": "Laboratório Hacker de Campinas",
+      "address": "Rua Araribóia, 121 Ponte Preta, Campinas - SP 13041-350",
+      "latitude": -22.9178033,
+      "longitude": -47.0524533
+    },
+    "ap_user": None
+}]
+
+class CalendarTest(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["LHC_CHAT_ID"] = "1"
+        os.environ["TELEGRAM_API_TOKEN"] = "abcdef"
+        os.environ["MONTASTIC_RSS_URL"] = "https://lhc.net.br/rss"
+        os.environ["FINANCE_STATUS_URL"] = "https://lhc.net.br/finance"
+        os.environ["ICS_LOCATION"] = "https://gancio-eventos-lhc.fly.dev/api/events"
+
+    @patch('httpx.get')
+    @patch('ics.Calendar')
+    def test_today_2events_one_in_the_past_other_in_the_future(self, mock_Calendar, mock_get):
+        # GIVEN
+        mock_response = Mock()
+        mock_response.text = gancio_events_json_response  # Example ICS content
+        mock_get.return_value = mock_response
+
+        now = datetime.now()
+        print(f'Today is {now}')
+        two_hours_ago = now - timedelta(hours=2)
+        three_hours_ahead = now + timedelta(hours=3)
+        after_two_hours = three_hours_ahead + timedelta(hours=2)
+
+        event1 = Event("Oficina IoT", begin=two_hours_ago, end=now)
+        event2 = Event("CofeeOps", begin=three_hours_ahead, end=after_two_hours)
+
+        mock_calendar = Mock()
+        mock_calendar.events = [ event1, event2 ]
+        mock_Calendar.return_value = mock_calendar
+        # WHEN
+        events = cal.get_events("today")
+        print(events)
+        # THEN the test may run at a time when the event2 still in the future
+        if event2.begin.date() == datetime.today():
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0].name, "CofeeOps")
+        else:
+            self.assertEqual(len(events), 0)
+
+    @patch('httpx.get')
+    @patch('ics.Calendar')
+    def test_today_2events_one_in_the_past_other_now(self, mock_Calendar, mock_get):
+        # GIVEN
+        mock_response = Mock()
+        mock_response.text = gancio_events_json_response  # Example ICS content
+        mock_get.return_value = mock_response
+
+        now = datetime.now()
+        print(f'Today is {now}')
+        two_hours_ago = now - timedelta(hours=2)
+        after_two_hours = now + timedelta(hours=2)
+
+        event1 = Event("Oficina IoT", begin=two_hours_ago, end=now)
+        event2 = Event("CofeeOps", begin=(now+timedelta(seconds=1)), end=after_two_hours)
+
+        mock_calendar = Mock()
+        mock_calendar.events = [ event1, event2 ]
+        mock_Calendar.return_value = mock_calendar
+        # WHEN
+        events = cal.get_events("today")
+        print(events)
+        # THEN
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].name, "CofeeOps")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/calendar_test.py
+++ b/test/calendar_test.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime, timedelta
 
 from unittest.mock import patch, Mock
+from parameterized import parameterized
 
 from ics import Event
 
@@ -59,9 +60,14 @@ class CalendarTest(unittest.TestCase):
         os.environ["FINANCE_STATUS_URL"] = "https://lhc.net.br/finance"
         os.environ["ICS_LOCATION"] = "https://gancio-eventos-lhc.fly.dev/api/events"
 
+
+    @parameterized.expand([
+        ("today"),
+        ("future")
+    ])
     @patch('httpx.get')
     @patch('ics.Calendar')
-    def test_today_2events_one_in_the_past_other_in_the_future(self, mock_Calendar, mock_get):
+    def test_today_2events_one_in_the_past_other_in_the_future(self, when, mock_Calendar, mock_get):
         # GIVEN
         mock_response = Mock()
         mock_response.text = gancio_events_json_response  # Example ICS content
@@ -80,18 +86,22 @@ class CalendarTest(unittest.TestCase):
         mock_calendar.events = [ event1, event2 ]
         mock_Calendar.return_value = mock_calendar
         # WHEN
-        events = cal.get_events("today")
+        events = cal.get_events(when)
         print(events)
-        # THEN the test may run at a time when the event2 still in the future
+        # THEN the test may run at a time when the event2 will be tomorrow
         if event2.begin.date() == datetime.today():
             self.assertEqual(len(events), 1)
             self.assertEqual(events[0].name, "CofeeOps")
         else:
             self.assertEqual(len(events), 0)
 
+    @parameterized.expand([
+        ("today"),
+        ("future")
+    ])
     @patch('httpx.get')
     @patch('ics.Calendar')
-    def test_today_2events_one_in_the_past_other_now(self, mock_Calendar, mock_get):
+    def test_today_2events_one_in_the_past_other_now(self, when, mock_Calendar, mock_get):
         # GIVEN
         mock_response = Mock()
         mock_response.text = gancio_events_json_response  # Example ICS content
@@ -109,7 +119,7 @@ class CalendarTest(unittest.TestCase):
         mock_calendar.events = [ event1, event2 ]
         mock_Calendar.return_value = mock_calendar
         # WHEN
-        events = cal.get_events("today")
+        events = cal.get_events(when)
         print(events)
         # THEN
         self.assertEqual(len(events), 1)

--- a/test/calendar_test.py
+++ b/test/calendar_test.py
@@ -7,6 +7,12 @@ from parameterized import parameterized
 
 from ics import Event
 
+os.environ["LHC_CHAT_ID"] = "1"
+os.environ["TELEGRAM_API_TOKEN"] = "abcdef"
+os.environ["MONTASTIC_RSS_URL"] = "https://lhc.net.br/rss"
+os.environ["FINANCE_STATUS_URL"] = "https://lhc.net.br/finance"
+os.environ["ICS_LOCATION"] = "https://gancio-eventos-lhc.fly.dev/api/events"
+
 import joker.commands.calendar as cal
 
 gancio_events_json_response = [{
@@ -53,14 +59,6 @@ gancio_events_json_response = [{
 
 class CalendarTest(unittest.TestCase):
 
-    def setUp(self):
-        os.environ["LHC_CHAT_ID"] = "1"
-        os.environ["TELEGRAM_API_TOKEN"] = "abcdef"
-        os.environ["MONTASTIC_RSS_URL"] = "https://lhc.net.br/rss"
-        os.environ["FINANCE_STATUS_URL"] = "https://lhc.net.br/finance"
-        os.environ["ICS_LOCATION"] = "https://gancio-eventos-lhc.fly.dev/api/events"
-
-
     @parameterized.expand([
         ("today"),
         ("future")
@@ -89,12 +87,9 @@ class CalendarTest(unittest.TestCase):
         # WHEN
         events = cal.get_events(when)
         print(events)
-        # THEN the test may run at a time when the event2 will be tomorrow
-        # if event2.begin.date() == datetime.today():
+        # THEN
         self.assertEqual(len(events), 1, msg="It should contain the event that starts in the future")
         self.assertEqual(events[0].name, "CofeeOps", msg="It should be the event name that starts in the future")
-        # else:
-            # self.assertEqual(len(events), 0, msg="If the event is tomorrow, it should not be in the list")
 
     @parameterized.expand([
         ("today"),
@@ -156,8 +151,8 @@ class CalendarTest(unittest.TestCase):
         events = cal.get_events(when)
         print(events)
         # THEN
-        self.assertEqual(len(events), 2, msg="It should contain the two events")
-        self.assertEqual(min(events, key=lambda e: e.begin).name, "Oficina IoT", msg="First event do now match")
+        self.assertEqual(len(events), 2, msg="It should contain the two future events")
+        self.assertEqual(min(events, key=lambda e: e.begin).name, "Oficina IoT", msg="First event should be the earliest date")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Do modo que funciona hj se existem 2 eventos no mesmo dia, o `/quando` vai retornar somente o que tem horário mais cedo.

A alteração visa comparação de horário, portanto se o evento que iria começar mais cedo já passou, vai retornar o próximo evento do dia

Teste unitário adicionado para validação:

* Execução: `python -m unittest test/calendar_test.py`
* Foi necessária definição de variáveis de ambiente com _dummy values_
* Utilização de mocks para retorno do `httpx.get`, `Calendar(response.text)` e `datetime.now()`