### PR TITLE
calendar: conserto da lógica de comparação (continuação)

### DIFF
--- a/src/joker/commands/calendar.py
+++ b/src/joker/commands/calendar.py
@@ -24,13 +24,17 @@ def get_events(when=""):
     all_events = list({event for event in calendar.events})
     logger.info(f"Future Events: {all_events}")
 
+    today = datetime.date.today()
+    event_begin_date = event.begin.date()
+    event_begin_time = event.begin.time()
+
     if when == "future":
         events = [
-            event for event in all_events if (event.begin.date() > datetime.date.today()) or (event.begin.date() == datetime.date.today() and event.begin.time() >= datetime.datetime.now().time())
+            event for event in all_events if (event_begin_date > today) or (event_begin_date == today and event_begin_time >= datetime.datetime.now().time())
         ]
     elif when == "today":
         events = [
-            event for event in all_events if event.begin.date() == datetime.date.today() and event.begin.time() >= datetime.datetime.now().time()
+            event for event in all_events if event_begin_date == today and event_begin_time >= datetime.datetime.now().time()
         ]
     else:
         events = all_events

--- a/src/joker/commands/calendar.py
+++ b/src/joker/commands/calendar.py
@@ -22,10 +22,11 @@ def get_events(when=""):
     calendar = ics.Calendar(response.text)
 
     all_events = list({event for event in calendar.events})
+    logger.info(f"Future Events: {all_events}")
 
     if when == "future":
         events = [
-            event for event in all_events if event.begin.date() >= datetime.date.today() and event.begin.time() >= datetime.datetime.now().time()
+            event for event in all_events if (event.begin.date() > datetime.date.today()) or (event.begin.date() == datetime.date.today() and event.begin.time() >= datetime.datetime.now().time())
         ]
     elif when == "today":
         events = [
@@ -40,6 +41,7 @@ def get_events(when=""):
 async def quando(update, context):
     future_events = get_events("future")
     next_event = min(future_events, key=lambda e: e.begin)
+    logger.info(f"Next Event: {next_event}")
     if next_event:
         event = {
             "title": next_event.name,

--- a/src/joker/settings.py
+++ b/src/joker/settings.py
@@ -1,3 +1,4 @@
+import logging
 from decouple import config
 
 FINANCE_STATUS_URL = config("FINANCE_STATUS_URL")
@@ -6,3 +7,5 @@ LHC_CHAT_ID = config("LHC_CHAT_ID")
 TELEGRAM_API_TOKEN = config("TELEGRAM_API_TOKEN")
 MONTASTIC_RSS_URL = config("MONTASTIC_RSS_URL")
 STATUS_CHECK_INTERVAL = config("STATUS_CHECK_INTERVAL", default=30, cast=int)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")


### PR DESCRIPTION
Continuando a tarefa iniciada aqui https://github.com/lhc/lhc-telegram-bot/pull/11

Ainda continha erro na lógica se caso o /quando fosse executado em um horário posterior ao horário do evento, em dias anteriores.

Adicionado também uma configuração básica de logging para testar como fica e tratar para outras partes da aplicação na tarefa https://github.com/lhc/lhc-telegram-bot/issues/23